### PR TITLE
chore: promote test2 to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-staging/test2/test2-test2-deploy.yaml
+++ b/config-root/namespaces/jx-staging/test2/test2-test2-deploy.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: test2
-        image: "nexus-docker.saas-ops.finline.app/q1323829945/test2:0.0.1"
+        image: "nexus-docker.saas-ops.finline.app/q1323829945/test2:0.0.2"
         ports:
         - containerPort: 8080
         imagePullPolicy: IfNotPresent

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@
 	    <tr>
 	      <td>test2</td>
 	      <td title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> test2</td>
-	      <td>0.0.1</td>
+	      <td>0.0.2</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -2,14 +2,14 @@
   path: helmfiles/jx-staging/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 0.0.1
+    appVersion: 0.0.2
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-12-07T07:27:25Z"
+    firstDeployed: "2022-12-07T07:38:01Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-12-07T07:27:25Z"
+    lastDeployed: "2022-12-07T07:38:01Z"
     name: test2
     releaseName: test2
     repositoryName: dev
     repositoryUrl: https://chartmuseum-jx.saas-ops.finline.app
     resourcePath: config-root/namespaces/jx-staging/test2
-    version: 0.0.1
+    version: 0.0.2

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: https://chartmuseum-jx.saas-ops.finline.app
 releases:
 - chart: dev/test2
-  version: 0.0.1
+  version: 0.0.2
   name: test2
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote test2 to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
