### PR TITLE
chore: promote h5-test to version 0.0.3

### DIFF
--- a/config-root/namespaces/my-staging/h5-test/h5-test-h5-test-deploy.yaml
+++ b/config-root/namespaces/my-staging/h5-test/h5-test-h5-test-deploy.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: h5-test
-        image: "nexus-docker.saas-ops.finline.app/q1323829945/h5-test:0.0.2"
+        image: "nexus-docker.saas-ops.finline.app/q1323829945/h5-test:0.0.3"
         ports:
         - containerPort: 80
         imagePullPolicy: IfNotPresent

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@
 	    <tr>
 	      <td>h5-test</td>
 	      <td title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> h5-test</td>
-	      <td>0.0.2</td>
+	      <td>0.0.3</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -17,14 +17,14 @@
   path: helmfiles/my-staging/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 0.0.2
+    appVersion: 0.0.3
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-12-07T08:21:02Z"
+    firstDeployed: "2022-12-08T02:39:12Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-12-07T08:21:02Z"
+    lastDeployed: "2022-12-08T02:39:12Z"
     name: h5-test
     releaseName: h5-test
     repositoryName: dev
     repositoryUrl: https://chartmuseum-jx.saas-ops.finline.app
     resourcePath: config-root/namespaces/my-staging/h5-test
-    version: 0.0.2
+    version: 0.0.3

--- a/helmfiles/my-staging/helmfile.yaml
+++ b/helmfiles/my-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: https://chartmuseum-jx.saas-ops.finline.app
 releases:
 - chart: dev/h5-test
-  version: 0.0.2
+  version: 0.0.3
   name: h5-test
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote h5-test to version 0.0.3

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
