### PR TITLE
chore: promote h52 to version 0.0.19

### DIFF
--- a/config-root/namespaces/my-staging/h52/h52-h52-deploy.yaml
+++ b/config-root/namespaces/my-staging/h52/h52-h52-deploy.yaml
@@ -1,0 +1,28 @@
+# Source: h52/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: h52-h52
+  labels:
+    app: h52-h52
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'h52'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: my-staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: h52-h52
+  template:
+    metadata:
+      labels:
+        app: h52-h52
+    spec:
+      containers:
+      - name: h52
+        image: "nexus-docker.saas-ops.finline.app/q1323829945/h52:0.0.19"
+        ports:
+        - containerPort: 8080
+        imagePullPolicy: Always

--- a/config-root/namespaces/my-staging/h52/h52-ingress.yaml
+++ b/config-root/namespaces/my-staging/h52/h52-ingress.yaml
@@ -1,0 +1,28 @@
+# Source: h52/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-body-size: 1000m
+    meta.helm.sh/release-name: 'h52'
+  name: h52
+  namespace: my-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+  - http:
+      paths:
+      - pathType: ImplementationSpecific
+        backend:
+          service:
+            name: h52
+            port:
+              number: 8080
+        path: /
+    host: h52.saas.finline.app
+  tls:
+  - hosts:
+    - h52.saas.finline.app
+    secretName: "jx-privkey"

--- a/config-root/namespaces/my-staging/h52/h52-svc.yaml
+++ b/config-root/namespaces/my-staging/h52/h52-svc.yaml
@@ -1,0 +1,17 @@
+# Source: h52/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: h52
+  annotations:
+    meta.helm.sh/release-name: 'h52'
+  namespace: my-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+    targetPort: 8080
+  selector:
+    app: h52-h52

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,13 @@
 	      <td></td>
 	      <td></td>
 	    </tr>
+    <tr>
+	      <td>h52</td>
+	      <td title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> h52</td>
+	      <td>0.0.19</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
 
   </tbody>
 </table>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -28,3 +28,15 @@
     repositoryUrl: https://chartmuseum-jx.saas-ops.finline.app
     resourcePath: config-root/namespaces/my-staging/h5-test
     version: 0.0.3
+  - apiVersion: v1
+    appVersion: 0.0.19
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2022-12-12T02:43:27Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2022-12-12T02:43:27Z"
+    name: h52
+    releaseName: h52
+    repositoryName: dev
+    repositoryUrl: https://chartmuseum-jx.saas-ops.finline.app
+    resourcePath: config-root/namespaces/my-staging/h52
+    version: 0.0.19

--- a/helmfiles/my-staging/helmfile.yaml
+++ b/helmfiles/my-staging/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/h52
   version: 0.0.19
   name: h52
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/my-staging/helmfile.yaml
+++ b/helmfiles/my-staging/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: h5-test
   values:
   - jx-values.yaml
+- chart: dev/h52
+  version: 0.0.19
+  name: h52
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote h52 to version 0.0.19

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
