### PR TITLE
chore: promote h52 to version 1.0.0

### DIFF
--- a/config-root/namespaces/my-staging/h52/h52-h52-deploy.yaml
+++ b/config-root/namespaces/my-staging/h52/h52-h52-deploy.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: h52
-        image: "nexus-docker.saas-ops.finline.app/q1323829945/h52:0.0.25"
+        image: "nexus-docker.saas-ops.finline.app/q1323829945/h52:1.0.0"
         ports:
         - containerPort: 8080
         imagePullPolicy: Always

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@
     <tr>
 	      <td>h52</td>
 	      <td title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> h52</td>
-	      <td>0.0.25</td>
+	      <td>1.0.0</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -29,14 +29,14 @@
     resourcePath: config-root/namespaces/my-staging/h5-test
     version: 0.0.3
   - apiVersion: v1
-    appVersion: 0.0.25
+    appVersion: 1.0.0
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-12-12T05:36:30Z"
+    firstDeployed: "2022-12-12T05:47:02Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-12-12T05:36:30Z"
+    lastDeployed: "2022-12-12T05:47:02Z"
     name: h52
     releaseName: h52
     repositoryName: dev
     repositoryUrl: https://chartmuseum-jx.saas-ops.finline.app
     resourcePath: config-root/namespaces/my-staging/h52
-    version: 0.0.25
+    version: 1.0.0

--- a/helmfiles/my-staging/helmfile.yaml
+++ b/helmfiles/my-staging/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/h52
-  version: 0.0.25
+  version: 1.0.0
   name: h52
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote h52 to version 1.0.0

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
